### PR TITLE
Fix hardcoded macOS-specific Claude path

### DIFF
--- a/claude_wt/cli.py
+++ b/claude_wt/cli.py
@@ -207,7 +207,11 @@ def resume(branch_name: str):
                     break
                 current_wt = {"path": line[9:]}
             elif line.startswith("branch "):
-                current_wt["branch"] = line[7:]
+                branch = line[7:]
+                # Remove refs/heads/ prefix if present (for compatibility with different git versions)
+                if branch.startswith("refs/heads/"):
+                    branch = branch[11:]
+                current_wt["branch"] = branch
 
         # Check the last worktree entry
         if current_wt and current_wt.get("branch") == full_branch_name:
@@ -335,7 +339,11 @@ def clean(
                                 worktrees.append(current_wt)
                             current_wt = {"path": line[9:]}
                         elif line.startswith("branch "):
-                            current_wt["branch"] = line[7:]
+                            branch = line[7:]
+                            # Remove refs/heads/ prefix if present (for compatibility with different git versions)
+                            if branch.startswith("refs/heads/"):
+                                branch = branch[11:]
+                            current_wt["branch"] = branch
                     if current_wt:
                         worktrees.append(current_wt)
 
@@ -453,7 +461,11 @@ def list():
                     worktrees.append(current_wt)
                 current_wt = {"path": line[9:]}  # Remove 'worktree ' prefix
             elif line.startswith("branch "):
-                current_wt["branch"] = line[7:]  # Remove 'branch ' prefix
+                branch = line[7:]  # Remove 'branch ' prefix
+                # Remove refs/heads/ prefix if present (for compatibility with different git versions)
+                if branch.startswith("refs/heads/"):
+                    branch = branch[11:]
+                current_wt["branch"] = branch
         if current_wt:
             worktrees.append(current_wt)
 

--- a/claude_wt/cli.py
+++ b/claude_wt/cli.py
@@ -161,7 +161,7 @@ This directory must be added to .gitignore to prevent committing worktree data.
     )
 
     # Launch Claude
-    claude_path = shutil.which("claude") or "/Users/jlowin/.claude/local/claude"
+    claude_path = shutil.which("claude") or str(Path.home() / ".claude" / "local" / "claude")
     claude_cmd = [claude_path, "--add-dir", str(repo_root)]
     if query:
         claude_cmd.extend(["--", query])
@@ -224,7 +224,7 @@ def resume(branch_name: str):
         )
 
         # Launch Claude with --continue to resume conversation
-        claude_path = shutil.which("claude") or "/Users/jlowin/.claude/local/claude"
+        claude_path = shutil.which("claude") or str(Path.home() / ".claude" / "local" / "claude")
         claude_cmd = [claude_path, "--add-dir", str(repo_root), "--continue"]
         subprocess.run(claude_cmd, cwd=wt_path)
 


### PR DESCRIPTION
The `claude-wt` CLI was failing with an "unknown option '--add-dir'" error on Linux systems. The root cause was that the fallback path for the Claude executable was hardcoded to a macOS-specific path (`/Users/jlowin/.claude/local/claude`).

When `shutil.which("claude")` couldn't find the executable (because it's an alias, not in PATH), the code would fall back to this macOS `/User/*` path (which doesn't exist on Linux systems) for `jlowin` (who is one of a kind). This caused the subprocess to fail when trying to execute a non-existent file.

Fixed by replacing the hardcoded path with a dynamic path using `Path.home()` to construct the user-agnostic path
`~/.claude/local/claude`. This ensures the CLI works correctly across different operating systems and users (expect windows, probably, which I did not test and I'm not even sure is supported by claude).