### PR TITLE
fix: worktree detection

### DIFF
--- a/claude_wt/cli.py
+++ b/claude_wt/cli.py
@@ -207,7 +207,7 @@ def resume(branch_name: str):
                     break
                 current_wt = {"path": line[9:]}
             elif line.startswith("branch "):
-                current_wt["branch"] = line[7:]
+                current_wt["branch"] = line[7:].removeprefix("refs/heads/")
 
         # Check the last worktree entry
         if current_wt and current_wt.get("branch") == full_branch_name:
@@ -335,7 +335,7 @@ def clean(
                                 worktrees.append(current_wt)
                             current_wt = {"path": line[9:]}
                         elif line.startswith("branch "):
-                            current_wt["branch"] = line[7:]
+                            current_wt["branch"] = line[7:].removeprefix("refs/heads/")
                     if current_wt:
                         worktrees.append(current_wt)
 
@@ -453,7 +453,7 @@ def list():
                     worktrees.append(current_wt)
                 current_wt = {"path": line[9:]}  # Remove 'worktree ' prefix
             elif line.startswith("branch "):
-                current_wt["branch"] = line[7:]  # Remove 'branch ' prefix
+                current_wt["branch"] = line[7:].removeprefix("refs/heads/")  # Remove 'branch refs/heads/' prefix
         if current_wt:
             worktrees.append(current_wt)
 


### PR DESCRIPTION
Issue:
* multiple commands (`list`, `resume`, `clean`) would fail to detect worktrees
* this made aspects of the utility unusable - despite `git worktree list` showing them fine

Fix:
* there was an extra 'prefix' on the branch detection - removing this fixed it

Testing:
* Validated all commands (including `resume`) now work great! 🎉

P.S - thanks for making this utility @jlowin ! I've found it extremely useful already :))